### PR TITLE
lfpreviewer: fix for compatibility with chafa>=1.14

### DIFF
--- a/lfpreviewer
+++ b/lfpreviewer
@@ -159,7 +159,7 @@ image()
     [ -n "$w" ] || [ -n "$h" ] || exit 1
 
     if [ -z "$DISPLAY" ] || [ ! -p "$FIFO" ]; then
-        run chafa -s ${w}x${h} "$img"
+        run chafa --polite on -s ${w}x${h} "$img"
         return
     fi
 


### PR DESCRIPTION
Since version 1.14, by default chafa emits some control characters that confuse lf: https://github.com/gokcehan/lf/issues/1509  https://github.com/gokcehan/lf/issues/1582

This can be fixed by passing `--polite on` to chafa, which restores the pre-1.14 default behaviour.